### PR TITLE
Performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.bullet</groupId>
-    <artifactId>sudokuSolver</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>sudoku-solver</artifactId>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>Sudoku Solver</name>
@@ -22,6 +22,21 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/org/bullet/Cell.kt
+++ b/src/main/kotlin/org/bullet/Cell.kt
@@ -1,25 +1,33 @@
 package org.bullet
 
+import org.slf4j.LoggerFactory
+
 data class Cell(val id: Int) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(Cell::class.java)
+    }
+
     val groupList = mutableListOf<Group>()
 
     private fun findAvailableValues(moves: List<Move>): List<Int> {
-        return (1..9).filter { possibleValue ->
+        return (1..9).minus(
             moves
                 .filter { it.cell == this }
                 .flatMap { it.impossible }
-                .none { it == possibleValue }
-        }
+                .toSet()
+        )
     }
 
     fun findAvailableMove(moves: List<Move>): Move? {
-        val possibilities: List<Int> =
-            findAvailableValues(moves)
-                .filter { possibility ->
-                    groupList.all { it.findAvailableValues(moves).contains(possibility) }
-                }
 
-        println("For cell $this we have the possibilities: $possibilities")
+        val possibilities = findAvailableValues(moves).intersect(
+            groupList.fold(
+                (1..9).toSet(),
+                { sharedValues, group -> group.findAvailableValues(moves).intersect(sharedValues) }
+            )
+        ).toList()
+
+        logger.debug("For cell $this we have the possibilities: $possibilities")
         return if (possibilities.size > 1) {
             Move(Action.GUESS, this, possibilities[0])
         } else if (possibilities.size == 1) {

--- a/src/main/kotlin/org/bullet/Group.kt
+++ b/src/main/kotlin/org/bullet/Group.kt
@@ -10,17 +10,19 @@ data class Group(val id: Int, val cells: List<Cell>) {
     }
 
     fun countPopulatedCells(moves: List<Move>): Int {
-        return moves.count{ cells.contains(it.cell) }
+        return moves.count { cells.contains(it.cell) }
     }
 
     fun firstAvailableCell(moves: List<Move>): Cell? {
-        return cells.first{ cell -> moves.none { it.cell == cell } }
+        return cells.first { cell -> moves.none { it.cell == cell } }
     }
 
     fun findAvailableValues(moves: List<Move>): List<Int> {
-        return (1..9)
-            .filter { i ->
-                moves.filter { it.value == i }.none { cells.contains(it.cell) }
-            }
+        return (1..9).minus(
+            moves
+                .filter { cells.contains(it.cell) }
+                .map { it.value }
+                .toSet()
+        )
     }
 }

--- a/src/main/kotlin/org/bullet/SudokuSolver.kt
+++ b/src/main/kotlin/org/bullet/SudokuSolver.kt
@@ -1,6 +1,7 @@
 package org.bullet
 
 import org.bullet.Action.*
+import org.slf4j.LoggerFactory
 import java.lang.IllegalStateException
 
 fun main() {
@@ -20,6 +21,9 @@ fun <T> List<T>.plusMaybe(move: T?) : List<T>? {
 }
 
 class SudokuSolver(private val sudoku: Sudoku) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(SudokuSolver::class.java)
+    }
 
     fun solve(): List<Move> {
         return generateMoves(sudoku.generateSetup())
@@ -39,15 +43,16 @@ class SudokuSolver(private val sudoku: Sudoku) {
             .values
             .count() == moves.count()
 
-        println("Field complete: $fieldComplete")
+        logger.debug("Field complete: $fieldComplete")
         return fieldComplete
     }
 
     private fun findBestGroup(moves: List<Move>): Group? {
         return sudoku
             .groupList
-            .filter{ group -> group.countPopulatedCells(moves) < Group.GROUP_SIZE }
-            .maxBy{ it.countPopulatedCells(moves) }
+            .map { group -> Pair(group, group.countPopulatedCells(moves)) }
+            .filter{ pair -> pair.second < Group.GROUP_SIZE }
+            .maxBy{ it.second }?.first
     }
 
     private fun backTrack(moves: List<Move>): List<Move> {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Improved the code so it has to make far fewer iterations when looking for available values/moves and the best group.

Using JMH, the previous code base had the following performance:
Benchmark                                             Mode  Cnt   Score   Error  Units
KotlinSudokuSolverBenchmark.benchmarkKotlinCode      thrpt   25  90,844 ± 1,599  ops/s
KotlinSudokuSolverBenchmark.benchmarkKotlinCode:JFR  thrpt          NaN            N/A

After the improvements it boosted to the following:
Refactored findBestGroup:
Benchmark                                             Mode  Cnt    Score    Error  Units
KotlinSudokuSolverBenchmark.benchmarkKotlinCode      thrpt   25  386,184 ± 34,570  ops/s
KotlinSudokuSolverBenchmark.benchmarkKotlinCode:JFR  thrpt           NaN             N/A